### PR TITLE
Native app : step pip install snowflake-cli added

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Launch the application locally using:
    ```
 
 ### Natively on Snowflake
+To configure the application mode, update the `mode` parameter in `src/settings_config.json
+Set to `"native"` for running natively in Snowflake.
+
+Install snowflake-cli
+   ```bash
+      pip install snowflake-cli
+   ```
+
 
 To deploy the application natively in Snowflake, use the following command:
    ```bash


### PR DESCRIPTION

Hi Guys,
Installing the in-native app needs snowcli.
I have added the Native app: step pip install snowflake-cli added.

Here are some more suggestions(I am also working on)
1)python needs to freeze to 3.11
2)For RAG OCR/normal mode needs to be  used

Thanks
Mahantesh